### PR TITLE
grossweight API endpoint

### DIFF
--- a/test/freight_messages.py
+++ b/test/freight_messages.py
@@ -138,23 +138,4 @@ messages = [
       ]
     }
   },
-
-  {
-    "type": "SHIPMENT",
-    "referenceId": "S00001175",
-    "organizations": ["FAA"],
-    "estimatedTimeArrival": "2020-11-20T00:00:00",
-    "transportPacks": {
-      "nodes": [
-        {
-          "totalWeight": {
-            "weight": "3",
-            "unit": "KILOGRAMS"
-          }
-        }
-      ]
-    }
-  },
-
-
 ]


### PR DESCRIPTION
-  returns total weight of all shipments in pounds, ounces or kilograms.
-  supports `grossweight/pounds`, `grossweight/ounces`, `grossweight/kilograms`